### PR TITLE
rake: add bootstrap task for bundler and librarian

### DIFF
--- a/lib/tasks/bootstrap.rake
+++ b/lib/tasks/bootstrap.rake
@@ -1,0 +1,18 @@
+desc 'Set up gems and vendor modules'
+task :bootstrap do
+  Rake::Task[:bundle].invoke
+  Rake::Task[:vendor].invoke
+end
+
+desc "Install gems from Gemfile"
+task :bundle do
+  $stderr.puts "---> Running bundler"
+  system "bundle install"
+end
+
+desc 'Update vendor modules with librarian-puppet'
+task :vendor do
+  $stderr.puts "---> Running librarian-puppet"
+  system "bundle exec librarian-puppet install"
+end
+


### PR DESCRIPTION
The task is created with new users in mind. I find myself typing these two
commands in whenever I check out a new Puppet module or other repo that uses
Puppet and modules from Puppet Forge, so this task wraps them up in a
convenient package.
