### PR TITLE
Add Sensu example

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -2,7 +2,11 @@ forge 'http://forge.puppetlabs.com/'
 
 mod 'puppetlabs/stdlib', '~> 3.0'
 mod 'puppetlabs/apt', '~> 1.1'
+
+mod 'puppetlabs/rabbitmq', :git => 'git@github.com:puppetlabs/puppetlabs-rabbitmq.git'
+
 mod 'pdxcat/collectd', '~> 0.0'
+
 mod 'gds/graphite', :git => 'git://github.com/gds-operations/puppet-graphite.git'
 mod 'gds/gstatsd', :git => 'git@github.com:alphagov/puppet-gstatsd.git'
 mod 'rsyslog', :git => 'git@github.com:philandstuff/puppet-rsyslog.git'
@@ -10,3 +14,7 @@ mod 'logstash',
   :git => 'git://github.com/electrical/puppet-logstash.git'
 mod 'curl',
   :git => 'git://github.com/alphagov/puppet-curl.git'
+
+mod 'sensu/sensu'
+
+mod 'thomasvandoren/redis'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -1,11 +1,20 @@
 FORGE
   remote: http://forge.puppetlabs.com/
   specs:
+    maestrodev/wget (1.2.0)
     pdxcat/collectd (0.0.3)
       puppetlabs/stdlib (>= 2.0.0)
     puppetlabs/apt (1.1.0)
       puppetlabs/stdlib (>= 2.2.1)
+    puppetlabs/firewall (0.3.1)
+    puppetlabs/gcc (0.0.3)
     puppetlabs/stdlib (3.2.0)
+    sensu/sensu (0.7.5)
+      puppetlabs/apt (>= 0.0.0)
+      puppetlabs/stdlib (>= 0.0.0)
+    thomasvandoren/redis (0.0.9)
+      maestrodev/wget (>= 0.0.0)
+      puppetlabs/gcc (>= 0.0.0)
 
 GIT
   remote: git://github.com/alphagov/puppet-curl.git
@@ -44,6 +53,15 @@ GIT
   specs:
     rsyslog (2.0.0)
 
+GIT
+  remote: git@github.com:puppetlabs/puppetlabs-rabbitmq.git
+  ref: master
+  sha: 44bb086c96bf2e100f8ad149877bc6f2bce53a10
+  specs:
+    puppetlabs/rabbitmq (2.1.0)
+      puppetlabs/apt (>= 0.0.3)
+      puppetlabs/stdlib (>= 2.0.0)
+
 DEPENDENCIES
   curl (>= 0)
   gds/graphite (>= 0)
@@ -51,6 +69,9 @@ DEPENDENCIES
   logstash (>= 0)
   pdxcat/collectd (~> 0.0)
   puppetlabs/apt (~> 1.1)
+  puppetlabs/rabbitmq (>= 0)
   puppetlabs/stdlib (~> 3.0)
   rsyslog (>= 0)
+  sensu/sensu (>= 0)
+  thomasvandoren/redis (>= 0)
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Other tools which you may wish to consider:
  * [**diamond**](http://opensource.brightcove.com/project/diamond) is
    another system metric daemon in the same space as collectd
  * [**statsd**](https://github.com/etsy/statsd/) is the original
-   daemon which gstatsd copies.
+   daemon which gstatsd copies
 
 ### Logging
 
@@ -125,3 +125,21 @@ messages should be logged to disk in /var/log, but remote messages
 arriving via port 514 should not and should only be forwarded to
 logstash.
 
+### Alerting
+
+[**sensu**](http://sensuapp.org/) is a client/server system for running
+monitoring checks and handling results. Checks are defined in the puppet
+manifests (a very simple example is provided) and resultings displayed
+on a dashboard application. Additional handlers can also be configured
+to do things like dispatch emails or SMS messages.
+
+New checks can be written using the
+[sensu-plugin](https://github.com/sensu/sensu-plugin) framework or
+alternatively sensu can use existing Nagios plugins.
+
+#### Alternatives
+
+Other tools you may wish to consider:
+
+ * [**Nagios**](http://www.nagios.org/) is a similar but older
+   monitoring system

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,8 +5,8 @@ nodes = {
   'graphite' => {:ip => '172.16.10.10', :memory => 512},
   'node1' => {:ip => '172.16.10.11'},
   'logging' => {:ip => '172.16.10.12'},
-  'node2' => {:ip => '172.16.10.12'},
-  'sensu' => {:ip => '172.16.10.13', :memory => 512},
+  'node2' => {:ip => '172.16.10.13'},
+  'sensu' => {:ip => '172.16.10.14', :memory => 512},
 }
 node_defaults = {
   :domain => 'internal',

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,8 @@ nodes = {
   'graphite' => {:ip => '172.16.10.10', :memory => 512},
   'node1' => {:ip => '172.16.10.11'},
   'logging' => {:ip => '172.16.10.12'},
+  'node2' => {:ip => '172.16.10.12'},
+  'sensu' => {:ip => '172.16.10.13', :memory => 512},
 }
 node_defaults = {
   :domain => 'internal',
@@ -12,7 +14,7 @@ node_defaults = {
 }
 
 Vagrant.configure("2") do |config|
-  config.vm.box     = "puppet-precise64"
+  config.vm.box     = "precise64-puppetlabs"
   config.vm.box_url = "http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-1204-x64.box"
 
   config.vm.provision :puppet do |puppet|

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -9,7 +9,7 @@ sensu::dashboard_port: 8090
 sensu::dashboard_password: mysupersecretpassword
 sensu::install_repo: true
 sensu::purge_config: true
-sensu::rabbitmq_host: 172.16.10.13
+sensu::rabbitmq_host: 172.16.10.14
 sensu::rabbitmq_password: secret
 sensu::rabbitmq_port: 5672
 sensu::subscriptions: 'sensu-test'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -4,3 +4,13 @@ classes:
  - gds_collectd
  - gds_logging::client
  - gds_statsd
+ - sensu
+sensu::dashboard_port: 8090
+sensu::dashboard_password: mysupersecretpassword
+sensu::install_repo: true
+sensu::purge_config: true
+sensu::rabbitmq_host: 172.16.10.13
+sensu::rabbitmq_password: secret
+sensu::rabbitmq_port: 5672
+sensu::subscriptions: 'sensu-test'
+sensu::use_embedded_ruby: true

--- a/hieradata/node.sensu.internal.yaml
+++ b/hieradata/node.sensu.internal.yaml
@@ -1,0 +1,7 @@
+---
+classes:
+  - redis
+  - rabbitmq::server
+redis::version: 2.6.14
+sensu::server: true
+rabbitmq::server::env_config: "RABBITMQ_NODE_PORT=5672\nRABBITMQ_NODE_IP_ADDRESS=172.16.10.13\n"

--- a/hieradata/node.sensu.internal.yaml
+++ b/hieradata/node.sensu.internal.yaml
@@ -4,4 +4,4 @@ classes:
   - rabbitmq::server
 redis::version: 2.6.14
 sensu::server: true
-rabbitmq::server::env_config: "RABBITMQ_NODE_PORT=5672\nRABBITMQ_NODE_IP_ADDRESS=172.16.10.13\n"
+rabbitmq::server::env_config: "RABBITMQ_NODE_PORT=5672\nRABBITMQ_NODE_IP_ADDRESS=172.16.10.14\n"

--- a/manifests/nodes.pp
+++ b/manifests/nodes.pp
@@ -1,4 +1,39 @@
 # Use hiera as a lightweight ENC.
 node default {
   hiera_include('classes')
+
+  sensu::check { 'check_file_exists':
+    command     => 'test -e /tmp/missingfile',
+    handlers    => 'default',
+    subscribers => 'sensu-test',
+  }
+}
+
+node 'sensu.internal' inherits default {
+
+  rabbitmq_vhost { '/sensu':
+    ensure   => present,
+    provider => 'rabbitmqctl',
+  }
+
+  rabbitmq_user { 'sensu':
+    admin    => true,
+    password => 'secret',
+    provider => 'rabbitmqctl',
+  }
+
+  rabbitmq_user_permissions { 'sensu@/sensu':
+    configure_permission => '.*',
+    read_permission      => '.*',
+    write_permission     => '.*',
+    provider             => 'rabbitmqctl',
+  }
+
+  sensu::handler { 'default':
+    command => 'echo "sensu alert" >> /tmp/sensu.log',
+  }
+
+  Class['redis'] -> Class['sensu']
+  Class['rabbitmq::server'] -> Class['sensu']
+
 }

--- a/modules/gds_apt/manifests/init.pp
+++ b/modules/gds_apt/manifests/init.pp
@@ -1,21 +1,10 @@
-class gds_apt::impl {
-  class{'apt':
-    stage => 'setup',
-  }
+class gds_apt {
+  include 'apt'
   apt::source {'gds-ppa':
     location   => 'http://ppa.launchpad.net/gds/govuk/ubuntu',
     repos      => 'main',
     key        => '914D5813',
     key_server => 'pgp.mit.edu',
   }
-
-}
-
-class gds_apt {
-  stage {'setup':
-    before => Stage[main],
-  }
-  class {'gds_apt::impl':
-    stage => 'setup',
-  }
+  Exec['apt_update'] -> Package <| |>
 }


### PR DESCRIPTION
This brings up a sensu-server node and adds the sensu client to all the other nodes.

The configuration is _just_ enough to get it working. So no useful checks or handlers and various inter-node security measures to be implemented.
