### PR TITLE
Collectd config

### DIFF
--- a/modules/gds_collectd/manifests/init.pp
+++ b/modules/gds_collectd/manifests/init.pp
@@ -1,5 +1,11 @@
+# collectd installation
+#
+# collect metrics on cpu, memory and network
+# log to syslog at 'info' level
+# send data collected to graphite on the monitoring box
+#
 class gds_collectd {
-  class { '::collectd':
+  class { 'collectd':
     purge        => true,
     recurse      => true,
     purge_config => true,

--- a/modules/gds_collectd/manifests/init.pp
+++ b/modules/gds_collectd/manifests/init.pp
@@ -1,5 +1,16 @@
 class gds_collectd {
-  include collectd
-  include collectd::plugin::write_graphite
+  class { '::collectd':
+    purge        => true,
+    recurse      => true,
+    purge_config => true,
+  }
+
+  class { 'collectd::plugin::write_graphite':
+    graphitehost => '172.16.10.10',
+  }
+
+  collectd::plugin {'syslog':}
+  collectd::plugin {'memory':}
   collectd::plugin {'cpu':}
+  collectd::plugin {'interface':}
 }


### PR DESCRIPTION
Using puppet collectd config which allows us to specify the plugins we require.

With this i've sellected a few basic sets of metrics: cpu, network, memory and 
send the metrics collected to graphite on the monitoring box

/cc @philandstuff 
